### PR TITLE
tag text white on white when creating link

### DIFF
--- a/src/common/react-tagsinput.scss
+++ b/src/common/react-tagsinput.scss
@@ -43,4 +43,5 @@
   padding: 3px 5px;
   width: 100%;
   margin-bottom: 6px;
+  color: #495057;
 }


### PR DESCRIPTION
react-tagsinput-input is white on white in the tag field when creating a new link
form fields are ok, but the tags 
firefox 66.0 on archlinx xfce, change tested in inspector
form-group has no color, form-control does but is not applied to the react-tagsinput

chromium is otherwise ok, this change has no impact. unknown where chromium defaults or inherits color from. body?