### PR TITLE
Update QrCodeModal.tsx

### DIFF
--- a/src/short-urls/helpers/QrCodeModal.tsx
+++ b/src/short-urls/helpers/QrCodeModal.tsx
@@ -91,7 +91,7 @@ const QrCodeModal = ({ shortUrl: { shortUrl }, toggle, isOpen, selectedServer }:
         <div className="text-center">
           <div className="mb-3">
             <div>QR code URL:</div>
-            <ExternalLink className="indivisible" href={qrCodeUrl} />
+            <ExternalLink href={qrCodeUrl} />
             <CopyToClipboardIcon text={qrCodeUrl} />
           </div>
           <img src={qrCodeUrl} className="qr-code-modal__img" alt="QR code" />


### PR DESCRIPTION
Remove indivisible class to fix hyperlink extending outside modal.

Closes #417 