### PR TITLE
Support servers.json in a conf.d directory

### DIFF
--- a/config/docker/nginx.conf
+++ b/config/docker/nginx.conf
@@ -29,7 +29,6 @@ server {
     location ~* .+\.(css|js|html|png|jpe?g|gif|bmp|ico|json|csv|otf|eot|svg|svgz|ttf|woff|woff2|ijmap|pdf|tif|map) {
         try_files $uri $uri/ =404;
     }
-
     # When requesting a path without extension, try it, and return the index if not found
     # This allows HTML5 history paths to be handled by the client application
     location / {

--- a/config/docker/nginx.conf
+++ b/config/docker/nginx.conf
@@ -24,6 +24,12 @@ server {
     location ~* .+\.(css|js|html|png|jpe?g|gif|bmp|ico|json|csv|otf|eot|svg|svgz|ttf|woff|woff2|ijmap|pdf|tif|map) {
         try_files $uri $uri/ =404;
     }
+
+    # servers.json may be on the root, or in it's own directory (ie, mounting a volume in Cattle)
+    location = /servers.json {
+        try_files /servers.json /conf.d/servers.json;
+    }
+
     # When requesting a path without extension, try it, and return the index if not found
     # This allows HTML5 history paths to be handled by the client application
     location / {

--- a/config/docker/nginx.conf
+++ b/config/docker/nginx.conf
@@ -20,14 +20,14 @@ server {
         add_header Cache-Control "public";
     }
 
+    # servers.json may be on the root, or in conf.d directory
+    location = /servers.json {
+        try_files /servers.json /conf.d/servers.json;
+    }
+
     # When requesting static paths with extension, try them, and return a 404 if not found
     location ~* .+\.(css|js|html|png|jpe?g|gif|bmp|ico|json|csv|otf|eot|svg|svgz|ttf|woff|woff2|ijmap|pdf|tif|map) {
         try_files $uri $uri/ =404;
-    }
-
-    # servers.json may be on the root, or in it's own directory (ie, mounting a volume in Cattle)
-    location = /servers.json {
-        try_files /servers.json /conf.d/servers.json;
     }
 
     # When requesting a path without extension, try it, and return the index if not found


### PR DESCRIPTION
In Cattle (and maybe other Docker environments) you can't mount specific files, but have to mount a whole volume as a directory.

This PR allows the `servers.json` to be looked for inside a specific folder to support that use case.

Instead of running:

```
docker run --rm -v ${PWD}/misc/servers.json:/usr/share/nginx/html/servers.json -ti shlinkio/shlink-web-client
```

This PR allows to run:

```
docker run --rm -v ${PWD}/misc/:/usr/share/nginx/html/conf.d/ -ti shlinkio/shlink-web-client
```

With the same results.

The `conf.d` may become handy for other configuration files in the future (if there are any other ones).