### PR TITLE
Use SHA256 to generate server IDs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17902,6 +17902,11 @@
         }
       }
     },
+    "js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "compare-versions": "^3.6.0",
     "csvjson": "^5.1.0",
     "event-source-polyfill": "^1.0.22",
+    "js-sha256": "^0.9.0",
     "leaflet": "^1.7.1",
     "moment": "^2.29.1",
     "promise": "^8.1.0",

--- a/src/servers/CreateServer.tsx
+++ b/src/servers/CreateServer.tsx
@@ -1,18 +1,17 @@
 import { FC } from 'react';
-import { v4 as uuid } from 'uuid';
 import { RouterProps } from 'react-router';
 import { Result } from '../utils/Result';
 import NoMenuLayout from '../common/NoMenuLayout';
 import { StateFlagTimeout } from '../utils/helpers/hooks';
 import { ServerForm } from './helpers/ServerForm';
 import { ImportServersBtnProps } from './helpers/ImportServersBtn';
-import { ServerData, ServerWithId } from './data';
+import { ServerData, ServersMap } from './data';
 import './CreateServer.scss';
 
 const SHOW_IMPORT_MSG_TIME = 4000;
 
 interface CreateServerProps extends RouterProps {
-  createServer: (server: ServerWithId) => void;
+  createServer: (server: ServerData) => { type: string, newServers: ServersMap};
 }
 
 const ImportResult = ({ type }: { type: 'error' | 'success' }) => (
@@ -28,10 +27,11 @@ const CreateServer = (ImportServersBtn: FC<ImportServersBtnProps>, useStateFlagT
   const [ serversImported, setServersImported ] = useStateFlagTimeout(false, SHOW_IMPORT_MSG_TIME);
   const [ errorImporting, setErrorImporting ] = useStateFlagTimeout(false, SHOW_IMPORT_MSG_TIME);
   const handleSubmit = (serverData: ServerData) => {
-    const id = uuid();
+    const { newServers } = createServer({ ...serverData });
 
-    createServer({ ...serverData, id });
-    push(`/server/${id}`);
+    const newServer = Object.values(newServers)[0];
+    
+    push(`/server/${newServer.id}`);
   };
 
   return (

--- a/src/servers/reducers/servers.ts
+++ b/src/servers/reducers/servers.ts
@@ -1,5 +1,5 @@
+import { sha256 } from 'js-sha256';
 import { assoc, dissoc, map, pipe, reduce } from 'ramda';
-import { v4 as uuid } from 'uuid';
 import { Action } from 'redux';
 import { ServerData, ServersMap, ServerWithId } from '../data';
 import { buildReducer } from '../../utils/helpers/redux';
@@ -21,7 +21,7 @@ const serverWithId = (server: ServerWithId | ServerData): ServerWithId => {
     return server as ServerWithId;
   }
 
-  return assoc('id', uuid(), server);
+  return assoc('id', sha256(`${server.url}-${server.apiKey}`), server);
 };
 
 export default buildReducer<ServersMap, CreateServersAction>({
@@ -40,7 +40,7 @@ export const createServers = pipe(
   (newServers: ServersMap) => ({ type: CREATE_SERVERS, newServers }),
 );
 
-export const createServer = (server: ServerWithId) => createServers([ server ]);
+export const createServer = (server: ServerData) => createServers([ server ]);
 
 export const editServer = (serverId: string, serverData: Partial<ServerData>) => ({
   type: EDIT_SERVER,


### PR DESCRIPTION
To have stable, shareable server URLs, we use a hash of domain+ApiKey instead of a (local) UUID for each server.

A server defined like this:

```json
{
    "name": "Main server",
    "url": "https://doma.in",
    "apiKey": "09c972b7-506b-49f1-a19a-d729e22e599c"
  }
```

Will now always be at `http(s)://SHLINK_WEB_CLIENT/server/10a665ba8a86d62bed0025f9d5bf2ba6f7c2f0a95c57b8e86ec2936af348e35e`.

I'm marking this as draft because there's still a race condition in which users navigating to a server URL for the first time get a "server not found" error because the page hasn't loaded the `servers.json` file yet - and I want to address that here.

See #435