### PR TITLE
Make text of light tags legible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+* [#558](https://github.com/shlinkio/shlink-web-client/pull/558) Added dark text for tags where the generated background is too light, improving its legibility.
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* *Nothing*
+
+
 ## [3.5.1] - 2022-01-08
 ### Added
 * *Nothing*

--- a/src/tags/helpers/Tag.scss
+++ b/src/tags/helpers/Tag.scss
@@ -1,9 +1,9 @@
 .tag {
   color: #fff;
+}
 
-  &.light-generated-bg {
+.tag--light-bg {
     color: #000;
-  }
 }
 
 .tag:not(:last-child) {

--- a/src/tags/helpers/Tag.scss
+++ b/src/tags/helpers/Tag.scss
@@ -1,5 +1,9 @@
 .tag {
   color: #fff;
+
+  &.light-generated-bg {
+    color: #000;
+  }
 }
 
 .tag:not(:last-child) {

--- a/src/tags/helpers/Tag.tsx
+++ b/src/tags/helpers/Tag.tsx
@@ -13,7 +13,7 @@ interface TagProps {
 
 const Tag: FC<TagProps> = ({ text, children, clearable, className = '', colorGenerator, onClick, onClose }) => (
   <span
-    className={`badge tag ${className}`}
+    className={`badge tag ${className} ${colorGenerator.isColorLightForKey(text) ? 'light-generated-bg' : ''}`}
     style={{ backgroundColor: colorGenerator.getColorForKey(text), cursor: clearable || !onClick ? 'auto' : 'pointer' }}
     onClick={onClick}
   >

--- a/src/tags/helpers/Tag.tsx
+++ b/src/tags/helpers/Tag.tsx
@@ -1,4 +1,5 @@
 import { FC, MouseEventHandler } from 'react';
+import classNames from 'classnames';
 import ColorGenerator from '../../utils/services/ColorGenerator';
 import './Tag.scss';
 
@@ -13,7 +14,7 @@ interface TagProps {
 
 const Tag: FC<TagProps> = ({ text, children, clearable, className = '', colorGenerator, onClick, onClose }) => (
   <span
-    className={`badge tag ${className} ${colorGenerator.isColorLightForKey(text) ? 'light-generated-bg' : ''}`}
+    className={classNames('badge tag', className, { 'tag--light-bg': colorGenerator.isColorLightForKey(text) })}
     style={{ backgroundColor: colorGenerator.getColorForKey(text), cursor: clearable || !onClick ? 'auto' : 'pointer' }}
     onClick={onClick}
   >

--- a/src/utils/services/ColorGenerator.ts
+++ b/src/utils/services/ColorGenerator.ts
@@ -6,9 +6,10 @@ const { floor, random, sqrt, round } = Math;
 const letters = '0123456789ABCDEF';
 const buildRandomColor = () => `#${rangeOf(HEX_COLOR_LENGTH, () => letters[floor(random() * letters.length)]).join('')}`;
 const normalizeKey = (key: string) => key.toLowerCase().trim();
-const hexColorToRgbArray = (colorHex: string): number[] => (colorHex.match(/../g) || []).map(hex => parseInt(hex, 16) || 0);
+const hexColorToRgbArray = (colorHex: string): number[] =>
+  (colorHex.match(/../g) ?? []).map((hex) => parseInt(hex, 16) || 0);
 // HSP by Darel Rex Finley https://alienryderflex.com/hsp.html
-const perceivedLightness = (r: number = 0, g: number = 0, b: number = 0) => round(sqrt(0.299 * r ** 2 + 0.587 * g ** 2 + 0.114 * b ** 2));
+const perceivedLightness = (r = 0, g = 0, b = 0) => round(sqrt(0.299 * r ** 2 + 0.587 * g ** 2 + 0.114 * b ** 2));
 
 export default class ColorGenerator {
   private readonly colors: Record<string, string>;
@@ -40,11 +41,12 @@ export default class ColorGenerator {
     return color;
   };
 
-  public readonly isColorLightForKey = (key: string) => {
+  public readonly isColorLightForKey = (key: string): boolean => {
     const colorHex = this.getColorForKey(key).substring(1);
 
-    if (this.lights[colorHex] == undefined) {
+    if (!this.lights[colorHex]) {
       const rgb = hexColorToRgbArray(colorHex);
+
       this.lights[colorHex] = perceivedLightness(...rgb) >= 128;
     }
 

--- a/src/utils/services/ColorGenerator.ts
+++ b/src/utils/services/ColorGenerator.ts
@@ -2,16 +2,21 @@ import { rangeOf } from '../utils';
 import LocalStorage from './LocalStorage';
 
 const HEX_COLOR_LENGTH = 6;
-const { floor, random } = Math;
+const { floor, random, sqrt, round } = Math;
 const letters = '0123456789ABCDEF';
 const buildRandomColor = () => `#${rangeOf(HEX_COLOR_LENGTH, () => letters[floor(random() * letters.length)]).join('')}`;
 const normalizeKey = (key: string) => key.toLowerCase().trim();
+const hexColorToRgbArray = (colorHex: string): number[] => (colorHex.match(/../g) || []).map(hex => parseInt(hex, 16) || 0);
+// HSP by Darel Rex Finley https://alienryderflex.com/hsp.html
+const perceivedLightness = (r: number = 0, g: number = 0, b: number = 0) => round(sqrt(0.299 * r ** 2 + 0.587 * g ** 2 + 0.114 * b ** 2));
 
 export default class ColorGenerator {
   private readonly colors: Record<string, string>;
+  private readonly lights: Record<string, boolean>;
 
   public constructor(private readonly storage: LocalStorage) {
     this.colors = this.storage.get<Record<string, string>>('colors') ?? {};
+    this.lights = {};
   }
 
   public readonly getColorForKey = (key: string) => {
@@ -33,5 +38,16 @@ export default class ColorGenerator {
     this.storage.set('colors', this.colors);
 
     return color;
+  };
+
+  public readonly isColorLightForKey = (key: string) => {
+    const colorHex = this.getColorForKey(key).substring(1);
+
+    if (this.lights[colorHex] == undefined) {
+      const rgb = hexColorToRgbArray(colorHex);
+      this.lights[colorHex] = perceivedLightness(...rgb) >= 128;
+    }
+
+    return this.lights[colorHex];
   };
 }

--- a/test/tags/helpers/Tag.test.tsx
+++ b/test/tags/helpers/Tag.test.tsx
@@ -1,0 +1,85 @@
+import { Mock } from 'ts-mockery';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { ReactNode } from 'react';
+import ColorGenerator from '../../../src/utils/services/ColorGenerator';
+import { MAIN_COLOR } from '../../../src/utils/theme';
+import Tag from '../../../src/tags/helpers/Tag';
+
+describe('<Tag />', () => {
+  const onClick = jest.fn();
+  const onClose = jest.fn();
+  const isColorLightForKey = jest.fn(() => false);
+  const getColorForKey = jest.fn(() => MAIN_COLOR);
+  const colorGenerator = Mock.of<ColorGenerator>({ getColorForKey, isColorLightForKey });
+  let wrapper: ShallowWrapper;
+  const createWrapper = (text: string, clearable?: boolean, children?: ReactNode) => {
+    wrapper = shallow(
+      <Tag text={text} clearable={clearable} colorGenerator={colorGenerator} onClick={onClick} onClose={onClose}>
+        {children}
+      </Tag>,
+    );
+
+    return wrapper;
+  };
+
+  afterEach(jest.clearAllMocks);
+  afterEach(() => wrapper?.unmount());
+
+  it.each([
+    [ true ],
+    [ false ],
+  ])('includes an extra class when the color is light', (isLight) => {
+    isColorLightForKey.mockReturnValue(isLight);
+
+    const wrapper = createWrapper('foo');
+
+    expect((wrapper.prop('className') as string).includes('tag--light-bg')).toEqual(isLight);
+  });
+
+  it.each([
+    [ MAIN_COLOR ],
+    [ '#8A661C' ],
+    [ '#F7BE05' ],
+    [ '#5A02D8' ],
+    [ '#202786' ],
+  ])('includes generated color as backgroundColor', (generatedColor) => {
+    getColorForKey.mockReturnValue(generatedColor);
+
+    const wrapper = createWrapper('foo');
+
+    expect((wrapper.prop('style') as any).backgroundColor).toEqual(generatedColor);
+  });
+
+  it('invokes expected callbacks when appropriate events are triggered', () => {
+    const wrapper = createWrapper('foo', true);
+
+    expect(onClick).not.toBeCalled();
+    expect(onClose).not.toBeCalled();
+
+    wrapper.simulate('click');
+    expect(onClick).toHaveBeenCalledTimes(1);
+
+    wrapper.find('.tag__close-selected-tag').simulate('click');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    [ true, 1, 'auto' ],
+    [ false, 0, 'pointer' ],
+    [ undefined, 0, 'pointer' ],
+  ])('includes a close component when the tag is clearable', (clearable, expectedCloseBtnAmount, expectedCursor) => {
+    const wrapper = createWrapper('foo', clearable);
+
+    expect(wrapper.find('.tag__close-selected-tag')).toHaveLength(expectedCloseBtnAmount);
+    expect((wrapper.prop('style') as any).cursor).toEqual(expectedCursor);
+  });
+
+  it.each([
+    [ undefined, 'foo' ],
+    [ 'bar', 'bar' ],
+  ])('falls back to text as children when no children are provided', (children, expectedChildren) => {
+    const wrapper = createWrapper('foo', false, children);
+
+    expect(wrapper.html()).toContain(`>${expectedChildren}</span>`);
+  });
+});

--- a/test/utils/services/ColorGenerator.test.ts
+++ b/test/utils/services/ColorGenerator.test.ts
@@ -44,4 +44,19 @@ describe('ColorGenerator', () => {
     expect(storageMock.set).toHaveBeenCalledTimes(1);
     expect(storageMock.get).toHaveBeenCalledTimes(1);
   });
+
+  describe('isColorLightForKey', () => {
+    it.each([
+      [ '#4696e5', true ], // Shlink brand color
+      [ '#8A661C', false ],
+      [ '#F7BE05', true ],
+      [ '#5A02D8', false ],
+      [ '#202786', false ],
+    ])('returns that the color for a key is light based on the color assigned to that key', (color, isLight) => {
+      colorGenerator.setColorForKey('foo', color);
+
+      expect(isLight).toEqual(colorGenerator.isColorLightForKey('foo'));
+      expect(isLight).toEqual(colorGenerator.isColorLightForKey('foo')); // To cover when color is already calculated
+    });
+  });
 });

--- a/test/utils/services/ColorGenerator.test.ts
+++ b/test/utils/services/ColorGenerator.test.ts
@@ -1,6 +1,7 @@
 import { Mock } from 'ts-mockery';
 import ColorGenerator from '../../../src/utils/services/ColorGenerator';
 import LocalStorage from '../../../src/utils/services/LocalStorage';
+import { MAIN_COLOR } from '../../../src/utils/theme';
 
 describe('ColorGenerator', () => {
   let colorGenerator: ColorGenerator;
@@ -47,7 +48,7 @@ describe('ColorGenerator', () => {
 
   describe('isColorLightForKey', () => {
     it.each([
-      [ '#4696e5', true ], // Shlink brand color
+      [ MAIN_COLOR, true ],
       [ '#8A661C', false ],
       [ '#F7BE05', true ],
       [ '#5A02D8', false ],


### PR DESCRIPTION
I found that many tags are difficult to read due to lack of contrast between the white text specified in the CSS and the random background colours, e.g.:

![Screenshot_20220105_174112](https://user-images.githubusercontent.com/28617290/148175602-049cef42-759a-412b-b930-34ff4911b906.png)

These could be improved by dynamically assessing the brightness of the tag colour, and applying a different text colour, e.g.:

![Screenshot_20220105_174407](https://user-images.githubusercontent.com/28617290/148175795-f8947f2d-9034-4687-a6e2-1456974f1271.png)

Here's an untested draft of my idea to fix it. Feedback would be appreciated as I don't know TypeScript.