### PR TITLE
Memoize ShlinkWebComponentContainer to fix flickering charts on re-renders

### DIFF
--- a/src/common/ShlinkWebComponentContainer.tsx
+++ b/src/common/ShlinkWebComponentContainer.tsx
@@ -1,5 +1,6 @@
 import type { Settings, ShlinkWebComponentType, TagColorsStorage } from '@shlinkio/shlink-web-component';
 import type { FC } from 'react';
+import { memo } from 'react';
 import type { ShlinkApiClientBuilder } from '../api/services/ShlinkApiClientBuilder';
 import type { FCWithDeps } from '../container/utils';
 import { componentFactory, useDependencies } from '../container/utils';
@@ -22,7 +23,11 @@ type ShlinkWebComponentContainerDeps = {
 const ShlinkWebComponentContainer: FCWithDeps<
 ShlinkWebComponentContainerProps,
 ShlinkWebComponentContainerDeps
-> = withSelectedServer(({ selectedServer, settings }) => {
+// FIXME Using `memo` here to solve a flickering effect in charts.
+//       memo is probably not the right solution. The root cause is the withSelectedServer HOC, but I couldn't fix the
+//       extra rendering there.
+//       This should be revisited at some point.
+> = withSelectedServer(memo(({ selectedServer, settings }) => {
   const {
     buildShlinkApiClient,
     TagColorsStorage: tagColorsStorage,
@@ -47,7 +52,7 @@ ShlinkWebComponentContainerDeps
       )}
     />
   );
-});
+}));
 
 export const ShlinkWebComponentContainerFactory = componentFactory(ShlinkWebComponentContainer, [
   'buildShlinkApiClient',


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink-web-component/issues/159

This PR works around an issue with charts flickering, by memoizing `ShlinkWebComponentContainer`, so that it does not get re-rendered when `withSelectedServer` does.