### PR TITLE
Fix importing servers in Firefox for Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 * [shlink-web-component#294](https://github.com/shlinkio/shlink-web-component/issues/294) Make sure "validate URL" control is not displayed in short URL creation/edition, when consuming Shlink >=4.0.0.
+* [#1130](https://github.com/shlinkio/shlink-web-client/issues/1130) Fix importing servers in Firefox for Android when the CSV file contains spaces.
 
 
 ## [4.1.0] - 2024-03-17

--- a/src/servers/helpers/ImportServersBtn.tsx
+++ b/src/servers/helpers/ImportServersBtn.tsx
@@ -87,7 +87,7 @@ const ImportServersBtn: FCWithDeps<ImportServersBtnConnectProps, ImportServersBt
         You can create servers by importing a CSV file with <b>name</b>, <b>apiKey</b> and <b>url</b> columns.
       </UncontrolledTooltip>
 
-      <input type="file" accept="text/csv" className="d-none" ref={ref} onChange={onFile} aria-hidden />
+      <input type="file" accept=".csv" className="d-none" ref={ref} onChange={onFile} aria-hidden />
 
       <DuplicatedServersModal
         isOpen={isModalOpen}


### PR DESCRIPTION
Closes #1130 

This PR changes the import servers file input from `accept="text/csv"` to `"aceppt=".csv"`.

The reason is that, with the former, Firefox for Android would not allow picking valid CSV files if they have spaces in their name.

The solution is not perfect, as now Firefox for Android allows to pick any file, but that's because it does not really support the `accept` attribute in file inputs. See https://caniuse.com/?search=input%20type%20file%20accept

With this change, Chrome for Android also allows to pick any file, but that was already its behavior before.

On desktop browsers the filtering works as expected, with the only limitation that you no longer can pick CSV files that don't have the CSV extension, and you can pick non-CSV files if they have the csv extension. But those are probably edge cases.

In any cases, Shlink handles the parsing of the file and displays a proper error message if an invalid file is picked, so this should put us in a better situation.