### PR TITLE
Dockerfile: add org.opencontainers.image.source LABEL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN cd /shlink-web-client && npm ci && npm run build
 FROM nginxinc/nginx-unprivileged:1.25-alpine
 ARG UID=101
 LABEL maintainer="Alejandro Celaya <alejandro@alejandrocelaya.com>"
+LABEL org.opencontainers.image.source=https://github.com/shlinkio/shlink-web-client
 
 USER root
 RUN rm -r /usr/share/nginx/html && rm /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
I'd like to take advantage of renovate's changelog support (https://docs.renovatebot.com/modules/datasource/docker/)

To do so, the recommended way is to add the standard OCI label `org.opencontainers.image.source`.
This is useful for all sorts of tools.

A full list of pre-defined annotations is available at: https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
