### PR TITLE
Feature/predictable server ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+* [#1360](https://github.com/shlinkio/shlink-web-client/issues/1360) Added ability for server IDs to be generated based on the server name and URL, instead of generating a random UUID.
+
+    This can improve sharing a predefined set of servers cia servers.json, env vars, or simply export and import your servers in some other device, and then be able to share server URLs which continue working.
+
+    All existing servers will keep their generated IDs in existing devices for backwards compatibility, but newly created servers will use the new approach.
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* *Nothing*
+
+
 ## [4.2.2] - 2024-10-19
 ### Added
 * *Nothing*

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![GitHub license](https://img.shields.io/github/license/shlinkio/shlink-web-client.svg?style=flat-square)](https://github.com/shlinkio/shlink-web-client/blob/main/LICENSE)
 
 [![Mastodon](https://img.shields.io/mastodon/follow/109329425426175098?color=%236364ff&domain=https%3A%2F%2Ffosstodon.org&label=follow&logo=mastodon&logoColor=white&style=flat-square)](https://fosstodon.org/@shlinkio)
-[![Bluesky](https://img.shields.io/badge/follow-shlinkio-0285FF.svg?style=flat-square&logo=bluesky&logoColor=white)](https://bsky.app/profile/shlinkio.bsky.social)
+[![Bluesky](https://img.shields.io/badge/follow-shlinkio-0285FF.svg?style=flat-square&logo=bluesky&logoColor=white)](https://bsky.app/profile/shlink.io)
 [![Paypal Donate](https://img.shields.io/badge/Donate-paypal-blue.svg?style=flat-square&logo=paypal&colorA=cccccc)](https://slnk.to/donate)
 
 A ReactJS-based progressive web application for [Shlink](https://shlink.io).

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "react-router-dom": "^6.27.0",
         "reactstrap": "^9.2.3",
         "redux-localstorage-simple": "^2.5.1",
-        "uuid": "^10.0.0",
         "workbox-core": "^7.1.0",
         "workbox-expiration": "^7.1.0",
         "workbox-precaching": "^7.1.0",
@@ -11580,19 +11579,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -20189,11 +20175,6 @@
     "util-deprecate": {
       "version": "1.0.2",
       "dev": true
-    },
-    "uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "react-router-dom": "^6.27.0",
     "reactstrap": "^9.2.3",
     "redux-localstorage-simple": "^2.5.1",
-    "uuid": "^10.0.0",
     "workbox-core": "^7.1.0",
     "workbox-expiration": "^7.1.0",
     "workbox-precaching": "^7.1.0",

--- a/scripts/docker/servers_from_env.sh
+++ b/scripts/docker/servers_from_env.sh
@@ -4,6 +4,8 @@ set -e
 
 ME=$(basename $0)
 
+# In order to allow people to pre-configure a server in their shlink-web-client instance via env vars, this function
+# dumps a servers.json file based on the values provided via env vars
 setup_single_shlink_server() {
   [ -n "$SHLINK_SERVER_URL" ] || return 0
   [ -n "$SHLINK_SERVER_API_KEY" ] || return 0

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -50,8 +50,8 @@ const App: FCWithDeps<AppProps, AppDeps> = (
   const isHome = location.pathname === '/';
 
   useEffect(() => {
-    // Try to fetch the remote servers if the list is empty at first
-    // We use a ref because we don't care if the servers list becomes empty later
+    // Try to fetch the remote servers if the list is empty during first render.
+    // We use a ref because we don't care if the servers list becomes empty later.
     if (Object.keys(initialServers.current).length === 0) {
       fetchServers();
     }

--- a/src/servers/CreateServer.tsx
+++ b/src/servers/CreateServer.tsx
@@ -8,8 +8,8 @@ import { NoMenuLayout } from '../common/NoMenuLayout';
 import type { FCWithDeps } from '../container/utils';
 import { componentFactory, useDependencies } from '../container/utils';
 import { useGoBack } from '../utils/helpers/hooks';
-import { randomUUID } from '../utils/utils';
 import type { ServerData, ServersMap, ServerWithId } from './data';
+import { ensureUniqueIds } from './helpers';
 import { DuplicatedServersModal } from './helpers/DuplicatedServersModal';
 import type { ImportServersBtnProps } from './helpers/ImportServersBtn';
 import { ServerForm } from './helpers/ServerForm';
@@ -44,12 +44,12 @@ const CreateServer: FCWithDeps<CreateServerProps, CreateServerDeps> = ({ servers
   const [errorImporting, setErrorImporting] = useTimeoutToggle(false, SHOW_IMPORT_MSG_TIME);
   const [isConfirmModalOpen, toggleConfirmModal] = useToggle();
   const [serverData, setServerData] = useState<ServerData>();
-  const saveNewServer = useCallback((theServerData: ServerData) => {
-    const id = randomUUID();
+  const saveNewServer = useCallback((newServerData: ServerData) => {
+    const [newServerWithUniqueId] = ensureUniqueIds(servers, [newServerData]);
 
-    createServers([{ ...theServerData, id }]);
-    navigate(`/server/${id}`);
-  }, [createServers, navigate]);
+    createServers([newServerWithUniqueId]);
+    navigate(`/server/${newServerWithUniqueId.id}`);
+  }, [createServers, navigate, servers]);
   const onSubmit = useCallback((newServerData: ServerData) => {
     setServerData(newServerData);
 

--- a/src/servers/helpers/index.ts
+++ b/src/servers/helpers/index.ts
@@ -6,9 +6,23 @@ import type { ServerData, ServersMap, ServerWithId } from '../data';
  * in lowercase and replacing invalid URL characters with hyphens.
  */
 function idForServer(server: ServerData): string {
-  // TODO Handle invalid URLs. If not valid url, use the value as is
-  const url = new URL(server.url);
-  return `${server.name} ${url.host}`.toLowerCase().replace(/[^a-zA-Z0-9-_.~]/g, '-');
+  let urlSegment = server.url;
+  try {
+    const { host, pathname } = new URL(urlSegment);
+    urlSegment = host;
+
+    // Remove leading slash from pathname
+    const normalizedPathname = pathname.substring(1);
+
+    // Include pathname in the ID, if not empty
+    if (normalizedPathname.length > 0) {
+      urlSegment = `${urlSegment} ${normalizedPathname}`;
+    }
+  } catch {
+    // If the server URL is not valid, use the value as is
+  }
+
+  return `${server.name} ${urlSegment}`.toLowerCase().replace(/[^a-zA-Z0-9-_.~]/g, '-');
 }
 
 export function serversListToMap(servers: ServerWithId[]): ServersMap {

--- a/src/servers/helpers/index.ts
+++ b/src/servers/helpers/index.ts
@@ -61,7 +61,7 @@ export function ensureUniqueIds(existingServers: ServersMap, serversList: Server
       iterations++;
     }
 
-    serversWithId.push({ id, ...server });
+    serversWithId.push({ ...server, id });
 
     // Add this server's ID to the list, so that it is taken into consideration for the next ones
     existingIds.add(id);

--- a/src/servers/helpers/index.ts
+++ b/src/servers/helpers/index.ts
@@ -1,0 +1,50 @@
+import { groupBy } from '@shlinkio/data-manipulation';
+import type { ServerData, ServersMap, ServerWithId } from '../data';
+
+/**
+ * Builds a potentially unique ID for a server, based on concatenating their name and the hostname of their domain, all
+ * in lowercase and replacing invalid URL characters with hyphens.
+ */
+function idForServer(server: ServerData): string {
+  const url = new URL(server.url);
+  return `${server.name} ${url.host}`.toLowerCase().replace(/[^a-zA-Z0-9-_.~]/g, '-');
+}
+
+export function serverWithId(server: ServerWithId | ServerData): ServerWithId {
+  if ('id' in server) {
+    return server;
+  }
+
+  const id = idForServer(server);
+  return { ...server, id };
+}
+
+export function serversListToMap(servers: ServerWithId[]): ServersMap {
+  return servers.reduce<ServersMap>(
+    (acc, server) => ({ ...acc, [server.id]: server }),
+    {},
+  );
+}
+
+const serversInclude = (serversList: ServerData[], { url, apiKey }: ServerData) =>
+  serversList.some((server) => server.url === url && server.apiKey === apiKey);
+
+export type DedupServersResult = {
+  /** Servers which already exist in the reference list */
+  duplicatedServers: ServerData[];
+  /** Servers which are new based on a reference list */
+  newServers: ServerData[];
+};
+
+/**
+ * Given a list of new servers, checks which of them already exist in a servers map, and which don't
+ */
+export function dedupServers(servers: ServersMap, serversToAdd: ServerData[]): DedupServersResult {
+  const serversList = Object.values(servers);
+  const { duplicatedServers = [], newServers = [] } = groupBy(
+    serversToAdd,
+    (server) => serversInclude(serversList, server) ? 'duplicatedServers' : 'newServers',
+  );
+
+  return { duplicatedServers, newServers };
+}

--- a/src/servers/reducers/remoteServers.ts
+++ b/src/servers/reducers/remoteServers.ts
@@ -1,11 +1,14 @@
 import type { HttpClient } from '@shlinkio/shlink-js-sdk';
 import pack from '../../../package.json';
 import { createAsyncThunk } from '../../utils/helpers/redux';
-import type { ServerData } from '../data';
 import { hasServerData } from '../data';
+import { ensureUniqueIds } from '../helpers';
 import { createServers } from './servers';
 
-const responseToServersList = (data: any): ServerData[] => (Array.isArray(data) ? data.filter(hasServerData) : []);
+const responseToServersList = (data: any) => ensureUniqueIds(
+  {},
+  (Array.isArray(data) ? data.filter(hasServerData) : []),
+);
 
 export const fetchServers = (httpClient: HttpClient) => createAsyncThunk(
   'shlink/remoteServers/fetchServers',

--- a/src/servers/reducers/servers.ts
+++ b/src/servers/reducers/servers.ts
@@ -1,7 +1,7 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
-import { randomUUID } from '../../utils/utils';
 import type { ServerData, ServersMap, ServerWithId } from '../data';
+import { serversListToMap, serverWithId } from '../helpers';
 
 interface EditServer {
   serverId: string;
@@ -14,19 +14,6 @@ interface SetAutoConnect {
 }
 
 const initialState: ServersMap = {};
-
-const serverWithId = (server: ServerWithId | ServerData): ServerWithId => {
-  if ('id' in server) {
-    return server;
-  }
-
-  return { ...server, id: randomUUID() };
-};
-
-const serversListToMap = (servers: ServerWithId[]): ServersMap => servers.reduce<ServersMap>(
-  (acc, server) => ({ ...acc, [server.id]: server }),
-  {},
-);
 
 export const { actions, reducer } = createSlice({
   name: 'shlink/servers',

--- a/src/servers/reducers/servers.ts
+++ b/src/servers/reducers/servers.ts
@@ -1,7 +1,7 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 import type { ServerData, ServersMap, ServerWithId } from '../data';
-import { serversListToMap, serverWithId } from '../helpers';
+import { serversListToMap } from '../helpers';
 
 interface EditServer {
   serverId: string;
@@ -57,10 +57,7 @@ export const { actions, reducer } = createSlice({
       },
     },
     createServers: {
-      prepare: (servers: ServerData[]) => {
-        const payload = serversListToMap(servers.map(serverWithId));
-        return { payload };
-      },
+      prepare: (servers: ServerWithId[]) => ({ payload: serversListToMap(servers) }),
       reducer: (state, { payload: newServers }: PayloadAction<ServersMap>) => ({ ...state, ...newServers }),
     },
   },

--- a/src/utils/forms/FormText.tsx
+++ b/src/utils/forms/FormText.tsx
@@ -1,5 +1,0 @@
-import type { FC, PropsWithChildren } from 'react';
-
-export const FormText: FC<PropsWithChildren<unknown>> = ({ children }) => (
-  <small className="form-text text-muted d-block">{children}</small>
-);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,9 +1,6 @@
 import type { SyntheticEvent } from 'react';
-import { v4 } from 'uuid';
 
 export const handleEventPreventingDefault = <T>(handler: () => T) => (e: SyntheticEvent) => {
   e.preventDefault();
   handler();
 };
-
-export const randomUUID = () => v4();

--- a/test/servers/helpers/ImportServersBtn.test.tsx
+++ b/test/servers/helpers/ImportServersBtn.test.tsx
@@ -68,11 +68,14 @@ describe('<ImportServersBtn />', () => {
     { btnName: 'Save anyway',savesDuplicatedServers: true },
     { btnName: 'Discard', savesDuplicatedServers: false },
   ])('creates expected servers depending on selected option in modal', async ({ btnName, savesDuplicatedServers }) => {
-    const existingServer: ServerWithId = {
+    const existingServerData: ServerData = {
       name: 'existingServer',
-      id: 'existingserver-s.test',
       url: 'http://s.test/existingUrl',
       apiKey: 'existingApiKey',
+    };
+    const existingServer: ServerWithId = {
+      ...existingServerData,
+      id: 'existingserver-s.test',
     };
     const newServer: ServerData = { name: 'newServer', url: 'http://s.test/newUrl', apiKey: 'newApiKey' };
     const { user } = setUp({}, { [existingServer.id]: existingServer });
@@ -86,7 +89,7 @@ describe('<ImportServersBtn />', () => {
 
     expect(createServersMock).toHaveBeenCalledWith(
       savesDuplicatedServers
-        ? [existingServer, expect.objectContaining(newServer)]
+        ? [expect.objectContaining(existingServerData), expect.objectContaining(newServer)]
         : [expect.objectContaining(newServer)],
     );
     expect(onImportMock).toHaveBeenCalledTimes(1);

--- a/test/servers/helpers/index.test.ts
+++ b/test/servers/helpers/index.test.ts
@@ -39,5 +39,31 @@ describe('index', () => {
         expect.objectContaining({ id: 'baz-s.test' }),
       ]);
     });
+
+    it('includes server paths when not empty', () => {
+      const result = ensureUniqueIds({}, [
+        fromPartial({ name: 'Foo', url: 'https://example.com' }),
+        fromPartial({ name: 'Bar', url: 'https://s.test/some/path' }),
+        fromPartial({ name: 'Baz', url: 'https://s.test/some/other-path-here/123' }),
+      ]);
+
+      expect(result).toEqual([
+        expect.objectContaining({ id: 'foo-example.com' }),
+        expect.objectContaining({ id: 'bar-s.test-some-path' }),
+        expect.objectContaining({ id: 'baz-s.test-some-other-path-here-123' }),
+      ]);
+    });
+
+    it('uses server URL verbatim when it is not a valid URL', () => {
+      const result = ensureUniqueIds({}, [
+        fromPartial({ name: 'Foo', url: 'invalid' }),
+        fromPartial({ name: 'Bar', url: 'this is not a URL' }),
+      ]);
+
+      expect(result).toEqual([
+        expect.objectContaining({ id: 'foo-invalid' }),
+        expect.objectContaining({ id: 'bar-this-is-not-a-url' }),
+      ]);
+    });
   });
 });

--- a/test/servers/helpers/index.test.ts
+++ b/test/servers/helpers/index.test.ts
@@ -1,0 +1,43 @@
+import { fromPartial } from '@total-typescript/shoehorn';
+import type { ServersMap } from '../../../src/servers/data';
+import { ensureUniqueIds } from '../../../src/servers/helpers';
+
+describe('index', () => {
+  describe('ensureUniqueIds', () => {
+    const servers: ServersMap = {
+      'the-name-example.com': fromPartial({}),
+      'another-name-example.com': fromPartial({}),
+      'short-domain-s.test': fromPartial({}),
+    };
+
+    it('returns expected list of servers when existing IDs conflict', () => {
+      const result = ensureUniqueIds(servers, [
+        fromPartial({ name: 'The name', url: 'https://example.com' }),
+        fromPartial({ name: 'Short domain', url: 'https://s.test' }),
+        fromPartial({ name: 'The name', url: 'https://example.com' }),
+      ]);
+
+      expect(result).toEqual([
+        expect.objectContaining({ id: 'the-name-example.com-1' }),
+        expect.objectContaining({ id: 'short-domain-s.test-1' }),
+        expect.objectContaining({ id: 'the-name-example.com-2' }),
+      ]);
+    });
+
+    it('returns expected list of servers when IDs conflict in provided list of servers', () => {
+      const result = ensureUniqueIds(servers, [
+        fromPartial({ name: 'Foo', url: 'https://example.com' }),
+        fromPartial({ name: 'Bar', url: 'https://s.test' }),
+        fromPartial({ name: 'Foo', url: 'https://example.com' }),
+        fromPartial({ name: 'Baz', url: 'https://s.test' }),
+      ]);
+
+      expect(result).toEqual([
+        expect.objectContaining({ id: 'foo-example.com' }),
+        expect.objectContaining({ id: 'bar-s.test' }),
+        expect.objectContaining({ id: 'foo-example.com-1' }),
+        expect.objectContaining({ id: 'baz-s.test' }),
+      ]);
+    });
+  });
+});

--- a/test/servers/reducers/remoteServers.test.ts
+++ b/test/servers/reducers/remoteServers.test.ts
@@ -9,8 +9,8 @@ describe('remoteServersReducer', () => {
     const httpClient = fromPartial<HttpClient>({ jsonRequest });
 
     it.each([
-      [
-        [
+      {
+        serversArray: [
           {
             name: 'acel.me from servers.json',
             url: 'https://acel.me',
@@ -22,7 +22,7 @@ describe('remoteServersReducer', () => {
             apiKey: '7a531c75-134e-4d5c-86e0-a71b7167b57a',
           },
         ],
-        {
+        expectedNewServers: {
           'acel.me-from-servers.json-acel.me': {
             id: 'acel.me-from-servers.json-acel.me',
             name: 'acel.me from servers.json',
@@ -36,9 +36,9 @@ describe('remoteServersReducer', () => {
             apiKey: '7a531c75-134e-4d5c-86e0-a71b7167b57a',
           },
         },
-      ],
-      [
-        [
+      },
+      {
+        serversArray: [
           {
             name: 'acel.me from servers.json',
             url: 'https://acel.me',
@@ -53,7 +53,7 @@ describe('remoteServersReducer', () => {
             apiKey: '7a531c75-134e-4d5c-86e0-a71b7167b57a',
           },
         ],
-        {
+        expectedNewServers: {
           'acel.me-from-servers.json-acel.me': {
             id: 'acel.me-from-servers.json-acel.me',
             name: 'acel.me from servers.json',
@@ -66,12 +66,19 @@ describe('remoteServersReducer', () => {
             url: 'http://localhost:8000',
             apiKey: '7a531c75-134e-4d5c-86e0-a71b7167b57a',
           },
+
         },
-      ],
-      ['<html></html>', {}],
-      [{}, {}],
-    ])('tries to fetch servers from remote', async (mockedValue, expectedNewServers) => {
-      jsonRequest.mockResolvedValue(mockedValue);
+      },
+      {
+        serversArray: '<html></html>',
+        expectedNewServers: {},
+      },
+      {
+        serversArray: {},
+        expectedNewServers: {},
+      },
+    ])('tries to fetch servers from remote', async ({ serversArray, expectedNewServers }) => {
+      jsonRequest.mockResolvedValue(serversArray);
       const doFetchServers = fetchServers(httpClient);
 
       await doFetchServers()(dispatch, vi.fn(), {});

--- a/test/servers/reducers/remoteServers.test.ts
+++ b/test/servers/reducers/remoteServers.test.ts
@@ -12,27 +12,25 @@ describe('remoteServersReducer', () => {
       [
         [
           {
-            id: '111',
             name: 'acel.me from servers.json',
             url: 'https://acel.me',
             apiKey: '07fb8a96-8059-4094-a24c-80a7d5e7e9b0',
           },
           {
-            id: '222',
             name: 'Local from servers.json',
             url: 'http://localhost:8000',
             apiKey: '7a531c75-134e-4d5c-86e0-a71b7167b57a',
           },
         ],
         {
-          111: {
-            id: '111',
+          'acel.me-from-servers.json-acel.me': {
+            id: 'acel.me-from-servers.json-acel.me',
             name: 'acel.me from servers.json',
             url: 'https://acel.me',
             apiKey: '07fb8a96-8059-4094-a24c-80a7d5e7e9b0',
           },
-          222: {
-            id: '222',
+          'local-from-servers.json-localhost-8000': {
+            id: 'local-from-servers.json-localhost-8000',
             name: 'Local from servers.json',
             url: 'http://localhost:8000',
             apiKey: '7a531c75-134e-4d5c-86e0-a71b7167b57a',
@@ -42,31 +40,28 @@ describe('remoteServersReducer', () => {
       [
         [
           {
-            id: '111',
             name: 'acel.me from servers.json',
             url: 'https://acel.me',
             apiKey: '07fb8a96-8059-4094-a24c-80a7d5e7e9b0',
           },
           {
-            id: '222',
             name: 'Invalid',
           },
           {
-            id: '333',
             name: 'Local from servers.json',
             url: 'http://localhost:8000',
             apiKey: '7a531c75-134e-4d5c-86e0-a71b7167b57a',
           },
         ],
         {
-          111: {
-            id: '111',
+          'acel.me-from-servers.json-acel.me': {
+            id: 'acel.me-from-servers.json-acel.me',
             name: 'acel.me from servers.json',
             url: 'https://acel.me',
             apiKey: '07fb8a96-8059-4094-a24c-80a7d5e7e9b0',
           },
-          333: {
-            id: '333',
+          'local-from-servers.json-localhost-8000': {
+            id: 'local-from-servers.json-localhost-8000',
             name: 'Local from servers.json',
             url: 'http://localhost:8000',
             apiKey: '7a531c75-134e-4d5c-86e0-a71b7167b57a',

--- a/test/servers/reducers/selectedServer.test.ts
+++ b/test/servers/reducers/selectedServer.test.ts
@@ -9,7 +9,6 @@ import {
   selectedServerReducerCreator,
   selectServer as selectServerCreator,
 } from '../../../src/servers/reducers/selectedServer';
-import { randomUUID } from '../../../src/utils/utils';
 
 describe('selectedServerReducer', () => {
   const dispatch = vi.fn();
@@ -41,7 +40,7 @@ describe('selectedServerReducer', () => {
       ['latest', MAX_FALLBACK_VERSION, 'latest'],
       ['%invalid_semver%', MIN_FALLBACK_VERSION, '%invalid_semver%'],
     ])('dispatches proper actions', async (serverVersion, expectedVersion, expectedPrintableVersion) => {
-      const id = randomUUID();
+      const id = crypto.randomUUID();
       const getState = createGetStateMock(id);
       const expectedSelectedServer = {
         id,
@@ -60,7 +59,7 @@ describe('selectedServerReducer', () => {
     });
 
     it('dispatches error when health endpoint fails', async () => {
-      const id = randomUUID();
+      const id = crypto.randomUUID();
       const getState = createGetStateMock(id);
       const expectedSelectedServer = fromPartial<NonReachableServer>({ id, serverNotReachable: true });
 
@@ -73,7 +72,7 @@ describe('selectedServerReducer', () => {
     });
 
     it('dispatches error when server is not found', async () => {
-      const id = randomUUID();
+      const id = crypto.randomUUID();
       const getState = vi.fn(() => fromPartial<ShlinkState>({ servers: {} }));
       const expectedSelectedServer: NotFoundServer = { serverNotFound: true };
 

--- a/test/servers/reducers/servers.test.ts
+++ b/test/servers/reducers/servers.test.ts
@@ -105,15 +105,6 @@ describe('serversReducer', () => {
 
         expect(payload).toEqual(list);
       });
-
-      it('generates an id for every provided server if they do not have it', () => {
-        const servers = Object.values(list).map(({ name, autoConnect, url, apiKey }) => (
-          { name, autoConnect, url, apiKey }
-        ));
-        const { payload } = createServers(servers);
-
-        expect(Object.values(payload).every(({ id }) => !!id)).toEqual(true);
-      });
     });
 
     describe('setAutoConnect', () => {


### PR DESCRIPTION
Closes #1360 

Change logic while creating servers, so that the server ID is computed from the name+domain, instead of generating a random UUID.

For example, for `{ "name": "My cool server", domain: "https://example.com", ... }`, the generated ID is `my-cool-server-example.com`.

If the ID is duplicated, we will append an auto-increment counter, starting with `1`, until no ID collission happens.

This ensures server URLs are predictable across environments, as long as names and domains are preserved. This is the case for environments where a `servers.json` file or env vars for a default server are provided.

As a nice side effect, the new URLs are more human friendly, and we can finally get rid of the `uuid` dependency without introducing breaking changes.

Existing servers that were previously created with a UUID will continue working normally, as once the ID is generated, there's no special treatment applied to it and it is simply used as is.