### PR TITLE
Work around issue with react-router + vitest in node >22.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,5 +11,5 @@ jobs:
   ci:
     uses: shlinkio/github-actions/.github/workflows/web-app-ci.yml@main
     with:
-      node-version: 22.10
+      node-version: 22.x
       publish-coverage: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   shlink_web_client_node:
     container_name: shlink_web_client_node
     user: 1000:1000 # With this, files created via `indocker` script will belong to the host user
-    image: node:22.10-alpine
+    image: node:22.12-alpine
     command: /bin/sh -c "cd /home/shlink/www && npm install && npm run start"
     volumes:
       - ./:/home/shlink/www

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,12 @@
 import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
 import { VitePWA } from 'vite-plugin-pwa';
 import { defineConfig } from 'vitest/config';
 import { manifest } from './manifest';
 import pack from './package.json' with { type: 'json' };
 
+const DEFAULT_NODE_VERSION = 'v22.10.0';
+const nodeVersion = process.version ?? DEFAULT_NODE_VERSION;
 const homepage = pack.homepage?.trim();
 
 /* eslint-disable-next-line no-restricted-exports */
@@ -51,5 +54,15 @@ export default defineConfig({
         lines: 95,
       },
     },
+
+    // Workaround for bug in react-router (or vitest module resolution) which causes different react-router versions to
+    // be resolved for the main package and dependencies who have a peer dependency in react-router.
+    // This ensures always the same version is resolved.
+    // See https://github.com/remix-run/react-router/issues/12785 for details
+    alias: nodeVersion > DEFAULT_NODE_VERSION
+      ? {
+        'react-router': resolve(__dirname, 'node_modules/react-router/dist/development/index.mjs'),
+      }
+      : undefined,
   },
 });


### PR DESCRIPTION
Workaround for https://github.com/remix-run/react-router/issues/12785