### PR TITLE
Pass HTTP credentials through to the API server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 * [shlink-web-component#637](https://github.com/shlinkio/shlink-web-component/pull/637) QR codes are now generated client-side, without hitting Shlink.
 * [shlink-web-component#641](https://github.com/shlinkio/shlink-web-component/issues/641) It is now possible to provide any logo to be used with QR codes.
+* [#1510](https://github.com/shlinkio/shlink-web-client/issues/1510) Existing HTTP credentials (cookies, TLS certs, authentication headers) are now automatically forwarded to the API server if appropriate [CORS headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Credentials) are set
 
 ### Changed
 * Update to `react-router` 7.0
@@ -16,7 +17,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Update to `@shlinkio/shlink-js-sdk` 2.0.0
 * Add `eslint-plugin-react-compiler`
 * Run unit tests in a headless browser using vitest browser mode and playwright.
-* Existing HTTP credentials (cookies, TLS certs, authentication headers) are now automatically forwarded to the API server if appropriate [CORS headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Credentials) are set
 
 ### Deprecated
 * *Nothing*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Update to `@shlinkio/shlink-js-sdk` 2.0.0
 * Add `eslint-plugin-react-compiler`
 * Run unit tests in a headless browser using vitest browser mode and playwright.
+* Existing HTTP credentials (cookies, TLS certs, authentication headers) are now automatically forwarded to the API server if appropriate [CORS headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Credentials) are set
 
 ### Deprecated
 * *Nothing*

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@reduxjs/toolkit": "^2.6.1",
         "@shlinkio/data-manipulation": "^1.0.3",
         "@shlinkio/shlink-frontend-kit": "^0.8.10",
-        "@shlinkio/shlink-js-sdk": "^2.0.0",
+        "@shlinkio/shlink-js-sdk": "^2.1.0",
         "@shlinkio/shlink-web-component": "^0.13.2",
         "bootstrap": "5.2.3",
         "bottlejs": "^2.0.1",
@@ -3438,9 +3438,9 @@
       }
     },
     "node_modules/@shlinkio/shlink-js-sdk": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@shlinkio/shlink-js-sdk/-/shlink-js-sdk-2.0.0.tgz",
-      "integrity": "sha512-+HOZlMTPe0EKE9uNlXe2EuAoQK3EmHUv0zvkN9oZvVkBCXR5FLfDKSab74xj9SJ6qgrd0JDvpxBVmFPKWoiNPg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@shlinkio/shlink-js-sdk/-/shlink-js-sdk-2.1.0.tgz",
+      "integrity": "sha512-K6zmA/A7Ux9hTn+ZjAm85YmMl7/v5XgZBM62syCxCsK7Tdw7Gg4+C06cZ2gUv+HWrHtv5IXsi4ax00++8Kg5vw==",
       "license": "MIT"
     },
     "node_modules/@shlinkio/shlink-web-component": {
@@ -13538,9 +13538,9 @@
       }
     },
     "@shlinkio/shlink-js-sdk": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@shlinkio/shlink-js-sdk/-/shlink-js-sdk-2.0.0.tgz",
-      "integrity": "sha512-+HOZlMTPe0EKE9uNlXe2EuAoQK3EmHUv0zvkN9oZvVkBCXR5FLfDKSab74xj9SJ6qgrd0JDvpxBVmFPKWoiNPg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@shlinkio/shlink-js-sdk/-/shlink-js-sdk-2.1.0.tgz",
+      "integrity": "sha512-K6zmA/A7Ux9hTn+ZjAm85YmMl7/v5XgZBM62syCxCsK7Tdw7Gg4+C06cZ2gUv+HWrHtv5IXsi4ax00++8Kg5vw=="
     },
     "@shlinkio/shlink-web-component": {
       "version": "0.13.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@reduxjs/toolkit": "^2.6.1",
     "@shlinkio/data-manipulation": "^1.0.3",
     "@shlinkio/shlink-frontend-kit": "^0.8.10",
-    "@shlinkio/shlink-js-sdk": "^2.0.0",
+    "@shlinkio/shlink-js-sdk": "^2.0.1",
     "@shlinkio/shlink-web-component": "^0.13.2",
     "bootstrap": "5.2.3",
     "bottlejs": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@reduxjs/toolkit": "^2.6.1",
     "@shlinkio/data-manipulation": "^1.0.3",
     "@shlinkio/shlink-frontend-kit": "^0.8.10",
-    "@shlinkio/shlink-js-sdk": "^2.0.1",
+    "@shlinkio/shlink-js-sdk": "^2.1.0",
     "@shlinkio/shlink-web-component": "^0.13.2",
     "bootstrap": "5.2.3",
     "bottlejs": "^2.0.1",

--- a/src/api/services/ShlinkApiClientBuilder.ts
+++ b/src/api/services/ShlinkApiClientBuilder.ts
@@ -23,7 +23,7 @@ export const buildShlinkApiClient = (httpClient: HttpClient) => (getStateOrSelec
     : getStateOrSelectedServer;
   const serverKey = `${apiKey}_${baseUrl}`;
 
-  const apiClient = apiClients[serverKey] ?? new ShlinkApiClient(httpClient, { apiKey, baseUrl });
+  const apiClient = apiClients[serverKey] ?? new ShlinkApiClient(httpClient, { apiKey, baseUrl }, { credentials: 'include' });
   apiClients[serverKey] = apiClient;
 
   return apiClient;

--- a/src/api/services/ShlinkApiClientBuilder.ts
+++ b/src/api/services/ShlinkApiClientBuilder.ts
@@ -23,7 +23,11 @@ export const buildShlinkApiClient = (httpClient: HttpClient) => (getStateOrSelec
     : getStateOrSelectedServer;
   const serverKey = `${apiKey}_${baseUrl}`;
 
-  const apiClient = apiClients[serverKey] ?? new ShlinkApiClient(httpClient, { apiKey, baseUrl }, { credentials: 'include' });
+  const apiClient = apiClients[serverKey] ?? new ShlinkApiClient(
+    httpClient,
+    { apiKey, baseUrl },
+    { requestCredentials: 'include' },
+  );
   apiClients[serverKey] = apiClient;
 
   return apiClient;


### PR DESCRIPTION
Closes #1510.

Since this requires a new, unreleased feature of the JS SDK, I've preemptively bumped the `package.json` version for safety. Once that has actually been stamped we can fix things up.