### PR TITLE
Use vitest/browser user events instead of testing library ones

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "@tailwindcss/vite": "^4.3.3",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
-        "@testing-library/user-event": "^14.6.3",
         "@total-typescript/shoehorn": "^0.1.2",
         "@types/node": "^26.1.2",
         "@types/react": "^19.2.18",
@@ -3744,19 +3743,6 @@
         "@types/react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@testing-library/user-event": {
-      "version": "14.6.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.3.tgz",
-      "integrity": "sha512-6dBq67jT8lE+JTE8Exm02Kt6ze43hz1jdiSpSJwtTZiT1xQQ6b7nZYTTQ9njdArdU8XklOwaDp/AbT/eYSKF4g==",
-      "dev": true,
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@total-typescript/shoehorn": {
@@ -11479,13 +11465,6 @@
       "requires": {
         "@babel/runtime": "^7.12.5"
       }
-    },
-    "@testing-library/user-event": {
-      "version": "14.6.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.3.tgz",
-      "integrity": "sha512-6dBq67jT8lE+JTE8Exm02Kt6ze43hz1jdiSpSJwtTZiT1xQQ6b7nZYTTQ9njdArdU8XklOwaDp/AbT/eYSKF4g==",
-      "dev": true,
-      "requires": {}
     },
     "@total-typescript/shoehorn": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@tailwindcss/vite": "^4.3.3",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
-    "@testing-library/user-event": "^14.6.3",
     "@total-typescript/shoehorn": "^0.1.2",
     "@types/node": "^26.1.2",
     "@types/react": "^19.2.18",

--- a/test/__helpers__/setUpTest.tsx
+++ b/test/__helpers__/setUpTest.tsx
@@ -1,10 +1,10 @@
 import type { ShlinkApiClient } from '@shlinkio/shlink-js-sdk';
 import type { RenderOptions } from '@testing-library/react';
 import { render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { fromPartial } from '@total-typescript/shoehorn';
 import type { PropsWithChildren, ReactElement } from 'react';
 import { Provider } from 'react-redux';
+import { userEvent } from 'vitest/browser';
 import { ContainerProvider } from '../../src/container/context';
 import type { RootState } from '../../src/store';
 import { setUpStore } from '../../src/store';

--- a/test/servers/ManageServersRowDropdown.test.tsx
+++ b/test/servers/ManageServersRowDropdown.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
-import type { UserEvent } from '@testing-library/user-event';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { MemoryRouter } from 'react-router';
+import type { UserEvent } from 'vitest/browser';
 import type { ServerWithId } from '../../src/servers/data';
 import { ManageServersRowDropdown } from '../../src/servers/ManageServersRowDropdown';
 import { checkAccessibility } from '../__helpers__/accessibility';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
+    "allowImportingTsExtensions": true,
     "jsx": "react-jsx",
     "lib": ["dom", "dom.iterable", "esnext"],
     "types": ["vite/client", "vitest/globals"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react';
 import { playwright } from '@vitest/browser-playwright';
 import { VitePWA } from 'vite-plugin-pwa';
 import { defineConfig } from 'vitest/config';
-import { manifest } from './manifest';
+import { manifest } from './manifest.ts';
 import pack from './package.json' with { type: 'json' };
 
 const homepage = pack.homepage?.trim();


### PR DESCRIPTION
Remove events from testing library, which are simulated, in favour of vitest browser ones, which run natively in the browser.